### PR TITLE
Build hornet with the build script

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,11 +111,11 @@ rm -rf /opt/hornet (only needed ONCE to switch to development branch)
 cd /opt (only needed ONCE to switch to development branch)
 git clone -b develop --single-branch https://github.com/gohornet/hornet (only needed ONCE to switch to development branch)
 
-systemctl stop hornet-alphanet && cd /opt/hornet && git pull && go build && cp hornet /opt/hornet-alphanet && systemctl start hornet-alphanet
+systemctl stop hornet-alphanet && cd /opt/hornet && git pull && scripts/build_hornet.sh && cp hornet /opt/hornet-alphanet && systemctl start hornet-alphanet
 ```
 
 If the version contains breaking changes:
 
 ```
-systemctl stop hornet-alphanet && cd /opt/hornet && rm -rf alphanetdb && rm -rf snapshots && git pull && go build && cp hornet /opt/hornet-alphanet && systemctl start hornet-alphanet
+systemctl stop hornet-alphanet && cd /opt/hornet && rm -rf alphanetdb && rm -rf snapshots && git pull && scripts/build_hornet.sh && cp hornet /opt/hornet-alphanet && systemctl start hornet-alphanet
 ```


### PR DESCRIPTION
I think it would be easier to manage the hornet version if the commit shows up in the dashboard. So everyone can check easily if he is up to date.

You should wait with merging until hornet has an alpha tag https://github.com/gohornet/hornet/issues/817
Because we need the tag for it to work properly